### PR TITLE
feat: add chartPath config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for publishing Helm charts to OCI compatible registries.
 | `verifyConditions` | Verify plugin configuration and login to Helm registry.  |
 | `prepare`          | Package Helm chart to local folder.                      |
 | `publish`          | Publish Helm chart to OCI registry.                      |
-
+| `chartPath`        | Chart directory, where the _Chart.yaml_ is located.      |
 ## Installation
 
 ```bash

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,15 +1,18 @@
 import fsPromises from 'fs/promises';
 import execa from 'execa';
 import yaml from 'js-yaml';
+import path from 'path';
 
 export default async (pluginConfig, context) => {
   const {logger, nextRelease: {version}} = context;
 
-  const ch = yaml.load(await fsPromises.readFile("./Chart.yaml"));
+  const chartPath = pluginConfig.chartPath || "./";
+  const filePath = path.join(chartPath, "/Chart.yaml");
+  const ch = yaml.load(await fsPromises.readFile(filePath));
 
   const appVersion = pluginConfig.skipAppVersion ? ch.appVersion : version;
 
-  await execa('helm', ['package', '--version', version, '--app-version', appVersion, "."], {
+  await execa('helm', ['package', '--version', version, '--app-version', appVersion, chartPath], {
     env: {HELM_EXPERIMENTAL_OCI: 1}
   });
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,11 +1,14 @@
 import fsPromises from  'fs/promises';
 import yaml from  'js-yaml';
 import execa from  'execa';
+import path from  'path';
 
 export default async (pluginConfig, context) => {
   const {logger, nextRelease: {version}} = context;
 
-  const ch = yaml.load(await fsPromises.readFile("./Chart.yaml"));
+  const chartPath = pluginConfig.chartPath || "./";
+  const filePath = path.join(chartPath, "/Chart.yaml");
+  const ch = yaml.load(await fsPromises.readFile(filePath));
 
   await execa('helm', ['push', `${ch.name}-${version}.tgz`, pluginConfig.registry], {
     env: {HELM_EXPERIMENTAL_OCI: 1}


### PR DESCRIPTION
## Description

This pull request introduces the ability to specify a custom chart path for Helm chart publishing within the semantic-release plugin. This enhancement allows the plugin to package and publish Helm charts located in subdirectories, not just the root directory of the repository.

## Changes

Added a new chartPath configuration option to specify the directory where the _Chart.yaml_ file is located.
Modified prepare.js and publish.js to use the custom chart path (if provided) for reading the _Chart.yaml_ file and packaging/publishing the Helm chart.

## Benefits

**Flexibility:** Users can organize their Helm charts in subdirectories and publish them without restructuring their projects.
**Convenience:** Provides an easier way to manage multiple Helm charts within a single repository.

## Usage

To use this feature, add the chartPath option in the semantic-release configuration, specifying the relative path to the chart directory. For example:

```json
{
  "chartPath": "./charts/mychart"
}
```

This will direct the plugin to look for the _Chart.yaml_ file and package the chart from the specified path.

## Compatibility

This change is backward compatible, defaulting to the current behavior (using the root directory) if _chartPath_ is not specified.